### PR TITLE
Correct the misuse of json.dumps()

### DIFF
--- a/python-for-beginners/17 - JSON/create_json_from_dict.py
+++ b/python-for-beginners/17 - JSON/create_json_from_dict.py
@@ -6,7 +6,7 @@ person_dict = {'first': 'Christopher', 'last':'Harrison'}
 person_dict['City']='Seattle'
 
 # Convert dictionary to JSON object
-person_json = json.dumps(person_dict)
+person_json = json.loads(person_dict)
 
 # Print JSON object
-print(person_json)
+print(json.dumps(person_json))

--- a/python-for-beginners/17 - JSON/create_json_with_list.py
+++ b/python-for-beginners/17 - JSON/create_json_with_list.py
@@ -12,7 +12,7 @@ languages_list = ['CSharp','Python','JavaScript']
 person_dict['languages']= languages_list
 
 # Convert dictionary to JSON object
-person_json = json.dumps(person_dict)
+person_json = json.loads(person_dict)
 
 # Print JSON object
-print(person_json)
+print(json.dumps(person_json))

--- a/python-for-beginners/17 - JSON/create_json_with_nested_dict.py
+++ b/python-for-beginners/17 - JSON/create_json_with_nested_dict.py
@@ -10,7 +10,7 @@ person_dict['City']='Seattle'
 staff_dict ={}
 staff_dict['Program Manager']=person_dict
 # Convert dictionary to JSON object
-staff_json = json.dumps(staff_dict)
+staff_json = json.loads(staff_dict)
 
 # Print JSON object
-print(staff_json)
+print(json.dumps(staff_json))


### PR DESCRIPTION
Correct the mistake where json.dumps() is used to convert dict to json object.
Usually  json.dumps() is used to convert JSON objects to Python String objects. 
So I purpose to use json.loads() here.